### PR TITLE
Fix JSON syntax in config-example

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -111,7 +111,7 @@
       "trainer_kwargs": {
         "n_steps": null,
         "batch_size": 32,
-        "n_epochs": 10,
+        "n_epochs": 10
       },
       "model_kwargs": {
         "num_lstm_layers": 3,
@@ -120,6 +120,5 @@
         "window_size": 5
       }
     }
-  },
-  //telegram and api
+  }
 }


### PR DESCRIPTION
## Summary
- remove trailing comma in the trainer configuration
- drop stray comment line
- ensure JSON config parses correctly

## Testing
- `python3 -m json.tool config-example.json`

------
https://chatgpt.com/codex/tasks/task_e_6845899608f0832d9046adfade48a329