### PR TITLE
Fix quick start typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ def _validate_freqai_include_timeframes()
     if freqai_enabled:
         main_tf = conf.get('timeframe', '5m') -> change to '1h' or the **min** timeframe of your choosing
 ```
-5. Make sure your package is edible after the the changes
+5. Make sure your package is editable after the changes
 ```shell
 pip install -e .
 ```


### PR DESCRIPTION
## Summary
- fix quick-start README typo

## Testing
- `grep -n "edible" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_6845897c546c832db5ca634ad0a7a956